### PR TITLE
deps: self_update migrated to self-github-update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fc"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Funcaptcha solver server"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ort = { version = "2.0.0-rc.2", features = ["ndarray", "half"] }
 rayon = "1.8.1"
 sha2 = "0.10.8"
 clap = { version = "4.4.18", features = ["derive", "env"] }
-self_update = { version = "0.40.0", default-features = false, features = ["rustls", "archive-tar", "compression-flate2"]  }
+self_update = { version = "0.39.0", package = "self-github-update", features = ["archive-tar", "compression-flate2"]  }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["full"] }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the `Cargo.toml` for the `fc` package to version `0.3.0`.
  - Downgraded the `self_update` dependency to `0.39.0` and renamed it to "self-github-update."

- **CI/CD**
  - Switched Rust toolchain from stable to nightly in the GitHub Actions workflow for better formatting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->